### PR TITLE
ci: build & push Docker image via GitHub Actions (replaces Docker Hub autobuild)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,53 @@
+name: Build and push Docker image
+
+# Replaces the retired Docker Hub Automated Build. Docker retired classic
+# Automated Builds (full retirement 2027-04-01). Builds the root Dockerfile and
+# pushes flybase/harvdev-docker to Docker Hub on every push to master.
+#
+# Requires two repository secrets (Settings -> Secrets and variables -> Actions):
+#   DOCKERHUB_USERNAME  - a Docker Hub user that can push to flybase/*
+#   DOCKERHUB_PASSWORD  - a Docker Hub access token (Read & Write scope)
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  workflow_dispatch: {}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: flybase/harvdev-docker
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Migrates `flybase/harvdev-docker` off the deprecated Docker Hub Automated Build (full retirement 2027-04-01) to GitHub Actions. Builds the root Dockerfile and pushes `flybase/harvdev-docker:latest` on push to master. Uses repo secrets DOCKERHUB_USERNAME + DOCKERHUB_PASSWORD. Actions pinned to current Node 24 versions.