### PR TITLE
fix(docker): unblock pip build (distutils packaging egg-info)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,10 @@ RUN apk add --update --no-cache \
     cargo \
     zip
 
+# Drop stale distutils egg-info so modern pip can upgrade 'packaging'
+# (otherwise pip fails: uninstall-distutils-installed-package).
+RUN rm -rf /usr/lib/python3*/site-packages/packaging-*.egg-info
+
 RUN pip install --upgrade pip &&\
     pip install wheel &&\
     pip install "Cython<3.0" pyyaml --no-build-isolation &&\ 


### PR DESCRIPTION
The Dockerfile failed to build on modern pip (26.x) with `error: uninstall-distutils-installed-package` on `packaging 21.3` (apk/distutils-installed). Removing its egg-info before the pip install lets pip upgrade it. Identical to the recent harvdev-proforma-parser fix; verified with a local `docker build`.